### PR TITLE
Optional debug option

### DIFF
--- a/example/state.js
+++ b/example/state.js
@@ -4,4 +4,12 @@ function callback(text)  {
   console.log(text);
 }
 
-aladdinGarageDoor('USER', 'PASSWORD', 'status', callback, 0, 1);
+aladdinGarageDoor(
+    'USER',         // your username 
+    'PASSWORD',     // your password
+    'status',       // command - get status
+    callback,       // callback that handles response from the API
+    0,              // garage #0
+    1,              // door #1
+    true            // allow debug
+);

--- a/index.js
+++ b/index.js
@@ -164,7 +164,8 @@ async function sendCommandToDoor(user, password, action, deviceNumber, doorNumbe
         return await getStatus(genieRPC_URI,genieRPC_Header,genieRPC_Auth,doorNumber,allowDebug);
     }
   } catch (err) {
-    console.log(err);
+    console.log(err.message);
+    debug('Error details',err,allowDebug);
     return 'STOPPED';
   }
   return 'STOPPED';
@@ -174,6 +175,9 @@ async function sendCommandToDoor(user, password, action, deviceNumber, doorNumbe
 module.exports = (user, password, action, callback, deviceNumber = 0, doorNumber = 1, allowDebug = 0) => {
   sendCommandToDoor(user, password, action, deviceNumber, doorNumber, allowDebug)
   .then(result => callback(result))
-  .catch(err => console.log(err));
+  .catch(err => {
+        console.log(err.message);
+        debug('Error details',err,allowDebug);
+  });
 };
 

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ async function sendCommandToDoor(user, password, action, deviceNumber, doorNumbe
 }
 
 // keping the callback signature for backwards compatibility
-module.exports = (user, password, action, callback, deviceNumber = 0, doorNumber = 1, allowDebug = 0) => {
+module.exports = (user, password, action, callback, deviceNumber = 0, doorNumber = 1, allowDebug = false) => {
   sendCommandToDoor(user, password, action, deviceNumber, doorNumber, allowDebug)
   .then(result => callback(result))
   .catch(err => {


### PR DESCRIPTION
Hi, I've noticed that you have pushed npm package with debug turned on. How about we add debug option as a configuration parameter? I'll need it in the interface to be able to pass it with every call.

Alternatively, I can refactor the whole thing to keep module-level state (like creds and debug option), but that would be a lot more work, and it would break the current interface (although it would make the implementation arguably prettier). 

Please let me know.